### PR TITLE
Fix #3, broken date-stamp in hashcash token

### DIFF
--- a/hashcash.js
+++ b/hashcash.js
@@ -39,7 +39,7 @@ Hashcash = {
         base_cash = '1:' + bitcost + ':';
     base_cash += formatLength2((date.getFullYear() % 100).toString());
     base_cash += formatLength2((date.getMonth() + 1).toString());
-    base_cash += formatLength2((date.getDay() + 1).toString());
+    base_cash += formatLength2((date.getDate()).toString());
     base_cash += ':' + resource + '::' + randString() + ':';
     
     this.makeWorkers(reqid);


### PR DESCRIPTION
The last two digits of the date-stamp should be the calendar day of the month (1-31), not the number representing the day-of-week (1-7)
